### PR TITLE
Feat/bcrypt

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -124,7 +124,8 @@ export default {
   },
 
   publicRuntimeConfig: {
-    copyright: process.env.COPYRIGHT || 'powered by walt.id'
+    copyright: process.env.COPYRIGHT || 'powered by walt.id',
+    salt: process.env.SALT
   },
 
   // Build Configuration: https://go.nuxtjs.dev/config-build

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -123,6 +123,10 @@ export default {
     middleware: ["auth"]
   },
 
+  publicRuntimeConfig: {
+    copyright: process.env.COPYRIGHT || 'powered by walt.id'
+  },
+
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {
     babel: {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@nuxtjs/axios": "^5.13.6",
         "@nuxtjs/i18n": "^7.2.0",
         "babel-eslint": "^10.1.0",
+        "bcryptjs": "^2.4.3",
         "bootstrap": "^5.1.3",
         "bootstrap-vue": "^2.21.2",
         "core-js": "^3.20.3",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -103,7 +103,7 @@
     </main>
     <footer class="fixed-bottom footer mt-auto py-3 bg-light">
       <div class="container">
-        <span class="text-muted">&#169; 2021 by walt.id </span>
+        <span class="text-muted">{{ $config.copyright }}</span>
       </div>
     </footer>
   </div>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -43,7 +43,7 @@
 </template>
 
 <script>
-const { genSaltSync, hashSync } = require('bcryptjs');
+const { hashSync } = require('bcryptjs');
 
 export default {
   name: "login",

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -36,7 +36,7 @@
       <a href="#" v-for="locale in availableLocales" :key="locale.code" @click.prevent.stop="$i18n.setLocale(locale.code)">
         <img :src="locale.flag" width="20px" height="15px" :alt="locale.iso" class="me-2 border border-white" />
       </a>
-      <p class="mt-3 mb-3 text-muted">&copy; 2021 walt.id </p>
+      <p class="mt-3 mb-3 text-muted">{{ $config.copyright }}</p>
      </form>
     </main>
   </section>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -43,6 +43,8 @@
 </template>
 
 <script>
+const { genSaltSync, hashSync } = require('bcryptjs');
+
 export default {
   name: "login",
   data () {
@@ -59,12 +61,15 @@ export default {
     }
   },
   methods: {
+    async bcrypt(val) {
+      return hashSync(val, this.$config.salt);
+    },
     async login () {
       try {
         const loginResponse = await this.$auth.loginWith("local", {
           data: {
-            id: this.email,
-            password: this.password
+            id: this.bcrypt(this.email),
+            password: this.bcrypt(this.password)
           }
         })
         this.$auth.setUser(loginResponse.data)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2182,6 +2182,11 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+bcryptjs@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
+  integrity sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"


### PR DESCRIPTION
While authentication is not implemented yet we must make sure that no data is sent in clear text as we might get into trouble with GDPR. We suggest loading `salt` into your `.env` and using bcrypt to hash everything that is sent by the client.